### PR TITLE
Update for Zig 0.16-dev compatibility

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -22,7 +22,7 @@ pub fn build(b: *std.Build) void {
     });
 
     // inject the cimgui header search path into the sokol C library compile step
-    dep_sokol.artifact("sokol_clib").addIncludePath(dep_cimgui.path("src"));
+    dep_sokol.artifact("sokol_clib").root_module.addIncludePath(dep_cimgui.path("src"));
 
     const mod_chips = b.addModule("chips", .{
         .root_source_file = b.path("src/chips/chips.zig"),

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -16,7 +16,7 @@
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.
@@ -25,16 +25,16 @@
     // internet connectivity.
     .dependencies = .{
         .chipz = .{
-            .url = "git+https://github.com/gunterhager/chipz.git#8b6ade7f6f1f61f4c1f4400a881618c7807d9200",
-            .hash = "chipz-0.0.0-gW-vWxnlDwB4tkS0G4FTJPZ0-vwj7e6KzclvlrSdB9jM",
+            .url = "git+https://github.com/gunterhager/chipz.git#879e6c50f9239a784efc7a967e11ecf812152c89",
+            .hash = "chipz-0.0.0-gW-vW3IGDwC1ahuYWySujNyq6ZshVomTk-AA6jObl-Ug",
         },
         .sokol = .{
-            .url = "git+https://github.com/floooh/sokol-zig.git#55e0bad86ed0af7b2da5449540d29554f818e38e",
-            .hash = "sokol-0.1.0-pb1HK6alLABjIgu2zvuMyBcxoar3b3HSVEvsCncjmhLG",
+            .url = "git+https://github.com/floooh/sokol-zig.git#de5906fb0f81f96e92c1c67a2b8a24dc50872207",
+            .hash = "sokol-0.1.0-pb1HK9ngNgD_m7L3HpbsyJ-jHRGVzcd672pjJDEPBQWh",
         },
         .cimgui = .{
-            .url = "git+https://github.com/floooh/dcimgui.git#3969c14f7c7abda0e4b59d2616b17b7fb9eb0827",
-            .hash = "cimgui-0.1.0-44ClkTt5hgBU8BelH8W_G8mso3ys_hrqNUWwJvaxXDs5",
+            .url = "git+https://github.com/floooh/dcimgui.git#4557d7526fdd977f46ca10c2bbdd63532254f8d6",
+            .hash = "cimgui-0.1.0-44ClkXnYlwBKnil7TfCWL9z1Zo_2YJCJREzrpdFiGvA1",
         },
     },
     .paths = .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -365,7 +365,7 @@ fn handleDroppedFiles() void {
     var obj_file: MZF = undefined;
     const path = sapp.getDroppedFilePath(0);
     std.debug.print("🚨 Loading file: {s}\n", .{path});
-    obj_file.load(std.fs.cwd(), path) catch |err| {
+    obj_file.load(.cwd(), path) catch |err| {
         std.debug.print("Error loading file '{s}': {}\n", .{ path, err });
     };
     std.debug.print("🚨 Name: {s}\n", .{obj_file.display_name});
@@ -376,8 +376,8 @@ fn handleDroppedFiles() void {
 
 pub fn main() void {
     const display = MZ800.displayInfo(null);
-    const width = display.view.width;
-    const height = display.view.height;
+    const width = display.viewport.width;
+    const height = display.viewport.height;
     std.debug.print("🚨 Display: {}x{}\n", .{ width, height });
     sapp.run(.{
         .init_cb = init,

--- a/src/system/mz800.zig
+++ b/src/system/mz800.zig
@@ -755,7 +755,7 @@ pub fn Type() type {
                     },
                     .buffer = if (selfOrNull) |self| .{ .Rgba8 = &self.fb } else null,
                 },
-                .view = .{
+                .viewport = .{
                     .x = 0,
                     .y = 0,
                     .width = DISPLAY.WIDTH,

--- a/src/system/mzf.zig
+++ b/src/system/mzf.zig
@@ -29,12 +29,21 @@ pub fn Type() type {
         display_name: [17]u8, // Name in regular ASCII
         data: [0x100000]u8, // 64K buffer
 
-        pub fn load(self: *Self, dir: std.fs.Dir, path: []const u8) !void {
-            var file = try dir.openFile(path, .{});
-            defer file.close();
-            const file_reader = file.reader();
-            self.header = try file_reader.readStructEndian(Header, .little);
-            const len = try file_reader.read(&self.data);
+        pub fn load(self: *Self, dir: std.Io.Dir, path: []const u8) !void {
+            const io = std.Io.Threaded.global_single_threaded.io();
+            const file = try dir.openFile(io, path, .{});
+            defer file.close(io);
+
+            const header_size = @sizeOf(Header);
+
+            // Read header bytes
+            var header_bytes: [header_size]u8 = undefined;
+            const header_read = try file.readPositionalAll(io, &header_bytes, 0);
+            if (header_read != header_size) return error.UnexpectedEndOfFile;
+            self.header = @bitCast(header_bytes);
+
+            // Read data after header
+            const len = try file.readPositionalAll(io, &self.data, header_size);
 
             if (self.header.attribute != .OBJ) {
                 // Currently only OBJ files can be read


### PR DESCRIPTION
## Summary
- Update chipz, sokol-zig, and dcimgui dependencies to latest versions supporting Zig 0.16-dev
- Fix `addIncludePath` → `root_module.addIncludePath` in build.zig
- Rename `DisplayInfo.view` → `viewport` to match updated chipz API
- Rewrite MZF file loading to use new `std.Io.Dir` / `std.Io.File` APIs (replaces removed `std.fs.Dir`)

## Test plan
- [x] `zig build` compiles the executable successfully
- [x] `zig build test` — 22/24 tests pass (2 pre-existing failures: missing test data file, stack overflow in bank switching tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)