### PR TITLE
Fix CTC CLK2 never driven (issue #8)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,16 @@
       "Bash(for dir:*)",
       "Bash(do echo:*)",
       "Read(//Users/gupi/Development/Private/zig-dev/mz800-emuz/$dir/**)",
-      "Bash(done)"
+      "Bash(done)",
+      "Bash(gh repo:*)",
+      "Bash(git remote:*)",
+      "Bash(gh label:*)",
+      "Bash(gh issue:*)",
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(gh pr:*)"
     ]
   }
 }

--- a/src/system/mz800.zig
+++ b/src/system/mz800.zig
@@ -377,6 +377,15 @@ pub fn Type() type {
                     // Toggle CLK1
                     bus ^= CTC_CLK1;
                     bus = self.ctc.setCLK1(bus);
+                    // CLK2 is driven by OUT1 of Counter 1.
+                    // Mirror counter[1].out onto the CLK2 bus pin;
+                    // Counter.setCLK only ticks counter 2 on a 1→0 falling edge.
+                    if (self.ctc.counter[1].out == 0) {
+                        bus &= ~CTC_CLK2;
+                    } else {
+                        bus |= CTC_CLK2;
+                    }
+                    bus = self.ctc.setCLK2(bus);
                 }
                 // PSG tick (~221.7 kHz)
                 if ((self.clock.ticks % clock_dividers.PSG_CLK) == 0) {


### PR DESCRIPTION
## Summary

- CTC Counter 2 was never clocked — `exec()` toggled CLK0 and CLK1 but had no code for CLK2
- On real MZ-800 hardware, CLK2 is driven by the **falling edge of Counter 1's output** (confirmed from the reference emulator's `ctc8253_ctc1_output_event`)
- After each CLK1 tick, mirror `counter[1].out` onto the `CTC_CLK2` bus pin and call `setCLK2`; `Counter.setCLK` only counts on a 1→0 transition, so Counter 2 ticks exactly when Counter 1's output falls

## Test plan

- [x] `zig build test` — all existing CTC unit tests pass

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)