### PR TITLE
Add MZF-to-CMT tape emulation with loading progress window

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,15 +4,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-SHARP MZ-800 emulator written in Zig, built on Andre Weissflog's [chipz](https://github.com/floooh/chipz) emulation infrastructure. Work in progress — does not yet fully boot into the monitor, but test programs can run. MZF files can be loaded via drag-and-drop.
+SHARP MZ-800 emulator written in Zig, built on Andre Weissflog's [chipz](https://github.com/floooh/chipz) emulation infrastructure. The system boots into the ROM monitor; loading **SHARP BASIC 1Z-016** doesn't work yet. MZF and WAV files can be loaded via drag-and-drop.
 
 Requires ROM binaries in `src/system/roms/`: `MZ800_ROM1.bin`, `MZ800_CGROM.bin`, `MZ800_ROM2.bin`.
 
 ## Commands
 
-**Build and run:**
+**Build and run** (requires Zig 0.16.0-dev or later):
 ```sh
 zig build run
+# optimized build:
+zig build --release=fast run
 ```
 
 **Run all Zig tests:**
@@ -20,10 +22,15 @@ zig build run
 zig build test
 ```
 
+**Run a single test** (e.g. `mz800`):
+```sh
+zig build test --test-filter mz800
+```
+
 **Build Z80 assembly test programs** (requires [z88dk](https://github.com/z88dk/z88dk)):
 ```sh
 z88dk-z80asm -b TestCharacters.asm
-z88dk-appmake +mz --org 0x2000 --audio -b TestCharacters.bin
+z88dk-appmake +mz --org 0x2000 --audio -b TestCharacters.bin -o TestCharacters.mzf
 ```
 
 ## Architecture
@@ -31,13 +38,15 @@ z88dk-appmake +mz --org 0x2000 --audio -b TestCharacters.bin
 The codebase has four main modules defined in `build.zig`:
 
 - **`chips`** (`src/chips/`) — Custom chip emulations not in chipz: `intel8253` (PIT), `gdg_whid65040_032` (CRT controller), `sn76489an` (PSG).
-- **`system`** (`src/system/`) — Full MZ-800 system integration: `mz800.zig` wires all chips together on a shared 128-bit bus. Also includes `mzf.zig` (MZF file format), `mzascii.zig`, `video.zig` (timing/geometry constants), `frequencies.zig` (clock dividers).
+- **`system`** (`src/system/`) — Full MZ-800 system integration. Entry point is `system.zig`; `mz800.zig` wires all chips together on a shared 128-bit bus. Also includes `cmt.zig` (CMT/tape emulation), `mzf.zig` (MZF file format), `mzascii.zig`, `video.zig` (timing/geometry constants), `frequencies.zig` (clock dividers).
 - **`ui`** (`src/ui/`) — ImGui debug windows for chips, built on sokol + cimgui.
-- **`main`** (`src/main.zig`) — Sokol app entry point: init/frame/cleanup/input callbacks.
+- **`main`** (`src/main.zig`) — Sokol app entry point: init/frame/cleanup/input/drag-drop callbacks.
 
 **Bus architecture:** All chips share a single `u128` bus. Each chip has pin assignments defined as compile-time constants in `mz800.zig`. Chip-select lines (PIO, PPI, CTC, GDG, PSG) occupy bus bits 36–40. The `tick()` function in `mz800.zig` dispatches memory and I/O requests each CPU cycle.
 
 **Clock:** The master clock (`CLK0` ~17.7 MHz) drives everything. Different chips tick at divided rates (`frequencies.zig`). The `exec()` function runs `N` master clock ticks per frame.
+
+**CMT (tape):** `cmt.zig` implements CMT emulation. It accepts WAV files (8-bit mono PCM, any sample rate) or synthesizes PCM from MZF files using the MZ-800 "SANE" tape protocol at 4096 Hz. Raw PCM is fed directly to PPI Port C bit 5 (RDATA); the ROM monitor decodes pulse widths. Motor control is via PC3 (M-ON, rising edge activates) with PC4 readback.
 
 **Tests** (`tests/`) are independent Zig test executables, each importing `chips` and `system` modules. Assembly test programs in `tests/asm/` produce `.mzf` files for drag-and-drop loading.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![MZ-800 Boot Screen](misc/boot_screen.png)
 
-**NOTE:** This project is work in progress. While it does boot into the ROM monitor there are still bugs and unimplemented features. E.g. loading **SHARP BASIC 1Z-016** doesn't work currently.
+**NOTE:** This project is work in progress. While it does successfully boot into the ROM monitor there are still bugs and unimplemented features. E.g. loading **SHARP BASIC 1Z-016** doesn't work currently.
 
 ## Loading MZF files
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -16,7 +16,7 @@
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    .minimum_zig_version = "0.16.0-dev.2915+065c6e794",
+    .minimum_zig_version = "0.16.0-dev.2962+08416b44f",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/src/main.zig
+++ b/src/main.zig
@@ -166,6 +166,7 @@ const UI_INTEL8253_Pins = [_]UI_CHIP.Pin{
 const UI_GDG = ui_intern.ui_gdg_whid65040_032.Type(.{ .bus = mz800.Bus, .gdg = mz800.GDG });
 const UI_GDG_Pins = [_]UI_CHIP.Pin{};
 const UI_KEYBOARD = ui_intern.ui_keyboard.Type(.{ .sys = MZ800 });
+const UI_CMT = ui_intern.ui_cmt.Type(.{ .sys = MZ800 });
 var sys: MZ800 = undefined;
 var gpa: DebugAllocator = .init;
 
@@ -175,6 +176,7 @@ var ui_intel8255: UI_INTEL8255 = undefined;
 var ui_intel8253: UI_INTEL8253 = undefined;
 var ui_gdg: UI_GDG = undefined;
 var ui_keyboard: UI_KEYBOARD = undefined;
+var ui_cmt: UI_CMT = undefined;
 
 export fn init() void {
     std.debug.print("🚨 Booting MZ-800...\n", .{});
@@ -247,6 +249,10 @@ export fn init() void {
         .sys = &sys,
         .origin = .{ .x = 20, .y = 300 },
     });
+    ui_cmt.initInPlace(.{
+        .sys = &sys,
+        .origin = .{ .x = 20, .y = 500 },
+    });
 
     // initialize sokol-imgui
     simgui.setup(.{
@@ -278,6 +284,7 @@ export fn frame() void {
     ui_intel8253.draw(sys.bus);
     ui_gdg.draw();
     ui_keyboard.draw();
+    ui_cmt.draw();
 
     host.gfx.draw(.{
         .display = sys.displayInfo(),
@@ -299,9 +306,11 @@ fn uiDrawMenu() void {
         if (ig.igBeginMenu("System")) {
             if (ig.igMenuItem("Reset")) {
                 sys.reset(false);
+                ui_cmt.open = false;
             }
             if (ig.igMenuItem("Soft Reset")) {
                 sys.reset(true);
+                ui_cmt.open = false;
             }
             ig.igSeparator();
             if (ig.igMenuItemEx("MZ-700 Mode", null, sys.preferred_is_mz700, true)) {
@@ -310,6 +319,9 @@ fn uiDrawMenu() void {
             ig.igSeparator();
             if (ig.igMenuItem("Keyboard")) {
                 ui_keyboard.open = true;
+            }
+            if (ig.igMenuItem("CMT")) {
+                ui_cmt.open = true;
             }
             ig.igEndMenu();
         }
@@ -395,10 +407,15 @@ fn loadMzfFile(path: [*:0]const u8) void {
         std.debug.print("🚨 Error loading MZF '{s}': {}\n", .{ path, err });
         return;
     };
-    std.debug.print("🚨 Name: {s}\n", .{obj_file.display_name});
-    std.debug.print("🚨 Loading address: 0x{x:0>4}\n", .{obj_file.header.loading_address});
-    std.debug.print("🚨 Starting address: 0x{x:0>4}\n", .{obj_file.header.start_address});
-    sys.load(obj_file);
+    std.debug.print("🚨 CMT: queuing MZF '{s}' for tape playback\n", .{obj_file.display_name});
+    sys.loadMzfAsCmt(obj_file) catch |err| {
+        const reason: []const u8 = switch (err) {
+            error.MzfTooLong => "program is too large for the CMT sample buffer",
+        };
+        std.debug.print("🚨 Cannot load MZF '{s}' into CMT: {s}\n", .{ path, reason });
+        return;
+    };
+    ui_cmt.open = true;
 }
 
 fn loadWavFile(path: [*:0]const u8) void {
@@ -439,6 +456,7 @@ fn loadWavFile(path: [*:0]const u8) void {
         std.debug.print("🚨 Cannot load WAV '{s}': {s}\n", .{ path, reason });
         return;
     };
+    ui_cmt.open = true;
 }
 
 pub fn main() void {

--- a/src/system/cmt.zig
+++ b/src/system/cmt.zig
@@ -12,8 +12,9 @@
 
 const std = @import("std");
 
-/// Maximum number of PCM samples (~45 seconds at 44100 Hz, sufficient for MZF tapes).
-pub const MAX_SAMPLES: usize = 2 * 1024 * 1024;
+/// Maximum number of PCM samples.
+/// 3 MB covers WAV files (~68 s at 44100 Hz) and worst-case 64 KB MZF tapes at 4096 Hz.
+pub const MAX_SAMPLES: usize = 3 * 1024 * 1024;
 
 pub const CMT = struct {
     const Self = @This();
@@ -109,6 +110,84 @@ pub const CMT = struct {
         self.position = 0;
     }
 
+    /// Encode an MZF file as synthetic PCM for CMT playback.
+    ///
+    /// Uses the MZ-800 "SANE" tape protocol at 4096 Hz (1 sample ≈ 244 µs):
+    ///   Short pulse [0xFF, 0x00]             — 488 µs, encodes bit 0
+    ///   Long  pulse [0xFF, 0xFF, 0x00, 0x00] — 976 µs, encodes bit 1 and stop bits
+    ///
+    /// Tape structure (matches g_mztape_format_sharp_sane, mztape.c lines 121–135):
+    ///   Long gap  (6400 short)  + Long TM  (40L+40S) + 2L
+    ///   Header (128 B, MSB-first, stop bit per byte)  + CHK (2 B, big-endian popcount) + 2L
+    ///   Short gap (11000 short) + Short TM (20L+20S)  + 2L
+    ///   Data   (N   B, MSB-first, stop bit per byte)  + CHK (2 B, big-endian popcount) + 2L
+    ///
+    /// Checksum = count of '1' bits (popcount) across all bytes in the block.
+    /// `header` must be the raw 128-byte MZF header; `data` the program bytes.
+    pub fn loadMzf(self: *Self, header: []const u8, data: []const u8) !void {
+        const SAMPLE_RATE: u32 = 4096;
+        var pos: usize = 0;
+
+        // ── Long gap: 6400 short pulses ──────────────────────────────────────
+        for (0..6400) |_| pos = try writeShort(&self.samples, pos);
+
+        // ── Long Tape Mark: 40 long + 40 short pulses ────────────────────────
+        for (0..40) |_| pos = try writeLong(&self.samples, pos);
+        for (0..40) |_| pos = try writeShort(&self.samples, pos);
+
+        // ── 2 long pulses ────────────────────────────────────────────────────
+        pos = try writeLong(&self.samples, pos);
+        pos = try writeLong(&self.samples, pos);
+
+        // ── Header block: 128 bytes MSB-first with stop bit ──────────────────
+        var checksum: u16 = 0;
+        for (header) |byte| {
+            checksum += @as(u16, @popCount(byte));
+            pos = try encodeByte(&self.samples, pos, byte);
+        }
+        // Header checksum big-endian (high byte first)
+        pos = try encodeByte(&self.samples, pos, @truncate(checksum >> 8));
+        pos = try encodeByte(&self.samples, pos, @truncate(checksum));
+
+        // ── 2 long pulses ────────────────────────────────────────────────────
+        pos = try writeLong(&self.samples, pos);
+        pos = try writeLong(&self.samples, pos);
+
+        // ── Short gap: 11000 short pulses ────────────────────────────────────
+        for (0..11000) |_| pos = try writeShort(&self.samples, pos);
+
+        // ── Short Tape Mark: 20 long + 20 short pulses ───────────────────────
+        for (0..20) |_| pos = try writeLong(&self.samples, pos);
+        for (0..20) |_| pos = try writeShort(&self.samples, pos);
+
+        // ── 2 long pulses ────────────────────────────────────────────────────
+        pos = try writeLong(&self.samples, pos);
+        pos = try writeLong(&self.samples, pos);
+
+        // ── Data block: N bytes MSB-first with stop bit ──────────────────────
+        checksum = 0;
+        for (data) |byte| {
+            checksum += @as(u16, @popCount(byte));
+            pos = try encodeByte(&self.samples, pos, byte);
+        }
+        // Data checksum big-endian (high byte first)
+        pos = try encodeByte(&self.samples, pos, @truncate(checksum >> 8));
+        pos = try encodeByte(&self.samples, pos, @truncate(checksum));
+
+        // ── 2 long pulses ────────────────────────────────────────────────────
+        pos = try writeLong(&self.samples, pos);
+        pos = try writeLong(&self.samples, pos);
+
+        self.sample_count = pos;
+        self.sample_rate = SAMPLE_RATE;
+        self.position = 0;
+        self.motor = false;
+        self.prev_m_on = false;
+        self.loaded = true;
+
+        std.debug.print("🚨 CMT: loaded MZF as {d} samples @ {d} Hz\n", .{ pos, SAMPLE_RATE });
+    }
+
     /// Parse and load a RIFF/WAV file from a byte slice.
     /// Validates: RIFF container, WAVE type, PCM format (1), mono, 8-bit samples.
     /// Accepts any sample rate. Copies samples into the internal buffer.
@@ -164,3 +243,39 @@ pub const CMT = struct {
         std.debug.print("🚨 CMT: loaded {d} samples @ {d} Hz\n", .{ count, sample_rate });
     }
 };
+
+/// Emit a short pulse [0xFF, 0x00] (≈ 488 µs at 4096 Hz, encodes bit 0).
+fn writeShort(samples: []u8, pos: usize) !usize {
+    if (pos + 2 > samples.len) return error.MzfTooLong;
+    samples[pos] = 0xFF;
+    samples[pos + 1] = 0x00;
+    return pos + 2;
+}
+
+/// Emit a long pulse [0xFF, 0xFF, 0x00, 0x00] (≈ 976 µs at 4096 Hz, encodes bit 1 / stop bit).
+fn writeLong(samples: []u8, pos: usize) !usize {
+    if (pos + 4 > samples.len) return error.MzfTooLong;
+    samples[pos] = 0xFF;
+    samples[pos + 1] = 0xFF;
+    samples[pos + 2] = 0x00;
+    samples[pos + 3] = 0x00;
+    return pos + 4;
+}
+
+/// Encode one byte MSB-first (8 data bits + 1 long stop bit) into `samples`.
+/// Returns the updated position, or error.MzfTooLong on buffer overflow.
+fn encodeByte(samples: []u8, pos: usize, byte_val: u8) !usize {
+    var p = pos;
+    var b = byte_val;
+    for (0..8) |_| {
+        if (b & 0x80 != 0) {
+            p = try writeLong(samples, p);
+        } else {
+            p = try writeShort(samples, p);
+        }
+        b <<= 1;
+    }
+    // Stop bit: always a long pulse (ref: mztape.c lines 624–626)
+    p = try writeLong(samples, p);
+    return p;
+}

--- a/src/system/mz800.zig
+++ b/src/system/mz800.zig
@@ -725,6 +725,14 @@ pub fn Type() type {
             self.cmt.configure(@intFromFloat(frequencies.CLK0));
         }
 
+        /// Encode an MZF file as synthetic CMT tape data for playback via the ROM loader.
+        pub fn loadMzfAsCmt(self: *Self, obj_file: MZF) !void {
+            const header_bytes = std.mem.asBytes(&obj_file.header);
+            const data_bytes = obj_file.data[0..obj_file.header.file_length];
+            try self.cmt.loadMzf(header_bytes, data_bytes);
+            self.cmt.configure(@intFromFloat(frequencies.CLK0));
+        }
+
         /// Load an MZF file into memory, resets CPU and starts the loaded start address.
         pub fn load(self: *Self, obj_file: MZF) void {
             self.reset(false);

--- a/src/ui/ui.zig
+++ b/src/ui/ui.zig
@@ -1,3 +1,4 @@
 pub const ui_intel8253 = @import("ui_intel8253.zig");
 pub const ui_gdg_whid65040_032 = @import("ui_gdg_whid65040_032.zig");
 pub const ui_keyboard = @import("ui_keyboard.zig");
+pub const ui_cmt = @import("ui_cmt.zig");

--- a/src/ui/ui_cmt.zig
+++ b/src/ui/ui_cmt.zig
@@ -1,0 +1,78 @@
+const std = @import("std");
+const ig = @import("cimgui");
+
+pub const TypeConfig = struct {
+    sys: type,
+};
+
+pub fn Type(comptime cfg: TypeConfig) type {
+    return struct {
+        const Self = @This();
+        const Sys = cfg.sys;
+
+        pub const Options = struct {
+            sys: *Sys,
+            origin: ig.ImVec2,
+            size: ig.ImVec2 = .{ .x = 300, .y = 90 },
+            open: bool = false,
+        };
+
+        sys: *Sys,
+        origin: ig.ImVec2,
+        size: ig.ImVec2,
+        open: bool,
+        last_open: bool,
+
+        pub fn initInPlace(self: *Self, opts: Options) void {
+            self.* = .{
+                .sys = opts.sys,
+                .origin = opts.origin,
+                .size = opts.size,
+                .open = opts.open,
+                .last_open = opts.open,
+            };
+        }
+
+        pub fn draw(self: *Self) void {
+            if (self.open != self.last_open) {
+                self.last_open = self.open;
+            }
+            if (!self.open) return;
+            ig.igSetNextWindowPos(self.origin, ig.ImGuiCond_FirstUseEver);
+            ig.igSetNextWindowSize(self.size, ig.ImGuiCond_FirstUseEver);
+            if (ig.igBegin("CMT", &self.open, ig.ImGuiWindowFlags_None)) {
+                const cmt = &self.sys.cmt;
+                if (!cmt.loaded) {
+                    ig.igTextUnformatted("No tape loaded.");
+                } else {
+                    const current: usize = @truncate(cmt.position >> 32);
+                    const total = cmt.sample_count;
+                    const fraction: f32 = if (total > 0)
+                        @min(1.0, @as(f32, @floatFromInt(current)) / @as(f32, @floatFromInt(total)))
+                    else
+                        0.0;
+
+                    // Progress bar filling the full window width
+                    var overlay_buf: [8:0]u8 = std.mem.zeroes([8:0]u8);
+                    _ = std.fmt.bufPrintZ(&overlay_buf, "{d:.0}%", .{fraction * 100.0}) catch {};
+                    ig.igProgressBar(fraction, .{ .x = -1.0, .y = 0.0 }, &overlay_buf);
+
+                    // Auto-close when playback reaches the end of the tape
+                    if (current >= total) self.open = false;
+
+                    // Motor status and time remaining
+                    const remaining = if (current < total) total - current else 0;
+                    const secs: f32 = @as(f32, @floatFromInt(remaining)) /
+                        @as(f32, @floatFromInt(cmt.sample_rate));
+                    var status_buf: [48:0]u8 = std.mem.zeroes([48:0]u8);
+                    _ = std.fmt.bufPrintZ(&status_buf, "Motor: {s}   Time left: {d:.1}s", .{
+                        if (cmt.motor) @as([]const u8, "ON") else "OFF",
+                        secs,
+                    }) catch {};
+                    ig.igTextUnformatted(&status_buf);
+                }
+            }
+            ig.igEnd();
+        }
+    };
+}


### PR DESCRIPTION
## Summary

- MZF files dropped onto the emulator are now encoded as synthetic CMT tape data, allowing the ROM's tape loading routine to run as it would on real hardware (instead of bypassing it with a direct memory load)
- Tape encoding matches the MZ-800 "SANE" format, verified against the `mztape.c` reference implementation: 4096 Hz sample rate, MSB-first bits with stop bits, popcount checksum sent big-endian, correct gap/tape-mark structure
- A new **CMT** window (System → CMT) shows a progress bar, motor status, and time remaining during playback; auto-opens on file drop, auto-closes at end of tape or on reset

## Test plan

- [ ] Drop a WAV file — CMT window auto-opens, progress bar advances as ROM reads the tape
- [ ] Drop an MZF file — CMT window auto-opens; issue load command at ROM prompt (`L`), confirm motor ON log, program loads and runs
- [ ] CMT window closes automatically when the tape reaches 100%
- [ ] System → Reset and Soft Reset close the CMT window
- [ ] System → CMT menu item opens/reopens the window manually
- [ ] Before any load, window shows "No tape loaded."
- [ ] `zig build test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)