### PR TITLE
Fix soft reset: restore ROM layout instead of mapping flat RAM

### DIFF
--- a/src/system/mz800.zig
+++ b/src/system/mz800.zig
@@ -879,27 +879,19 @@ pub fn Type() type {
         /// Reset the memory map depending on type of reset
         fn resetMemoryMap(self: *Self, soft: bool) void {
             self.prohibit_active = false;
-            // Soft reset: when pressing reset button while holding CTRL on keyboard
             if (soft) {
-                // All memory will be DRAM; VRAM intercept must be disabled.
+                // Soft reset: restore ROM layout but preserve RAM contents.
+                // VRAM is not intercepted after reset (matches reference implementation).
                 self.vram_banked_in = false;
-                self.rom1_mapped = false;
-                self.cgrom_mapped = false;
-                self.rom2_mapped = false;
-                self.mem.mapRAM(0x0000, MEM_CONFIG.MZ800.RAM_SIZE, &self.ram);
-                return;
+            } else {
+                // Hard reset: fill RAM with 0x00/0xff alternating (per SHARP Service Manual).
+                fillMem(&self.ram);
+                // VRAM is handled by GDG not regular memory mapping here
+                self.vram_banked_in = true;
             }
-
-            // Hard reset: when powering on or resetting with reset button
-            // Fill RAM with  0x00, 0xff alternating.
-            fillMem(&self.ram);
-
-            // According to SHARP Service Manual
             self.mem.mapROM(MEM_CONFIG.MZ800.ROM1_START, MEM_CONFIG.MZ800.ROM1_SIZE, &self.rom.rom1);
             self.mem.mapROM(MEM_CONFIG.MZ800.CGROM_START, MEM_CONFIG.MZ800.CGROM_SIZE, &self.rom.cgrom);
             self.mem.mapRAM(0x2000, 0x6000, self.ram[0x2000..0x8000]);
-            // VRAM is handled by GDG not regular memory mapping here
-            self.vram_banked_in = true;
             self.mem.mapRAM(0x8000, 0x4000, self.ram[0x8000..0xc000]);
             self.mem.mapRAM(0xc000, 0x2000, self.ram[0xc000..0xe000]);
             self.mem.mapROM(MEM_CONFIG.MZ800.ROM2_START, MEM_CONFIG.MZ800.ROM2_SIZE, &self.rom.rom2);

--- a/tests/mz800.test.zig
+++ b/tests/mz800.test.zig
@@ -83,13 +83,25 @@ test "soft reset sets vram_banked_in false" {
     // After hard reset (initInPlace calls reset(false)), VRAM is banked in.
     try expectEqual(sut.vram_banked_in, true);
 
-    // After soft reset, all memory is flat RAM, VRAM must NOT be intercepted.
+    // After soft reset, ROMs are restored but VRAM is NOT intercepted at 0x8000.
     sut.reset(true);
     try expectEqual(sut.vram_banked_in, false);
 
     // After hard reset again, VRAM is banked back in.
     sut.reset(false);
     try expectEqual(sut.vram_banked_in, true);
+}
+
+test "soft reset maps ROMs" {
+    const sut = try std.testing.allocator.create(MZ800);
+    defer std.testing.allocator.destroy(sut);
+    sut.initInPlace(mz800Options());
+
+    sut.reset(true);
+    try expect(checkROM1(sut));
+    try expect(checkCGROM(sut));
+    try expect(checkRAM(sut, 0x2000, 0xc000));
+    try expect(checkROM2(sut));
 }
 
 test "soft reset preserves RAM, hard reset fills RAM" {


### PR DESCRIPTION
## Summary

- Soft reset was mapping the entire address space as flat RAM, so the CPU tried to execute from 0x0000 in stale RAM instead of the ROM monitor
- Fix restores ROM1/CGROM/ROM2 at their standard addresses on soft reset (matching the reference implementation `mz800emu r247 memory_reset()`)
- The only behavioural difference from hard reset is preserved RAM contents and `vram_banked_in = false`
- Eliminated the near-duplicate ROM/RAM mapping sequence across the two reset branches

## Test plan

- [ ] `zig build test` passes (includes new `"soft reset maps ROMs"` test)
- [ ] `zig build run` → System menu → Soft Reset boots into the ROM monitor with RAM preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)